### PR TITLE
Fix comparison with maximum logging level

### DIFF
--- a/source/dlogg/strict.d
+++ b/source/dlogg/strict.d
@@ -183,7 +183,7 @@ synchronized class StyledStrictLogger(StyleEnum, US...) : IStyledLogger!StyleEnu
 	                }
 	                catch(Exception e)
 	                {
-	                    if(minOutputLevel != LoggingLevel.Muted)
+	                    if(minOutputLevel != StyleEnum.max)
 	                        writeln("Failed to write into log ", name);
 	                }
 	            }


### PR DESCRIPTION
Replaced LoggingLevel.Muted with StyleEnum.max, as the former is causing a compile error
with a StyledStrictLogger with custom logging level enum.